### PR TITLE
add equality method

### DIFF
--- a/lib/model.rb
+++ b/lib/model.rb
@@ -47,4 +47,10 @@ class Model
     send key
   end
 
+  def eql?(other)
+    other.instance_of?(self.class) &&
+        keys.all? { |k| send(k).nil? || other.send(k).nil? || send(k) == other.send(k) }
+  end
+  alias_method :==, :eql?
+
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -103,4 +103,25 @@ describe Model do
     expect(user[:first]).to eql 'Ken'
   end
 
+  it 'should know whether two models are equal' do
+    user1 = UserModel.new(first: 'Kartik', last: 'Chandran')
+    user2 = UserModel.new(first: 'Kartik', last: 'Chandran')
+    expect(user1).to eql user2
+    expect(user2).to eql user1
+  end
+
+  it 'should find a model equal to its intersection' do
+    UserModel.key(:id)
+    UserModel.key(:created)
+    user1 = UserModel.new(first: 'Kartik', last: 'Chandran', created: Time.now)
+    user2 = UserModel.new(id: 1, first: 'Kartik', last: 'Chandran')
+    expect(user1).to eql user2
+    expect(user2).to eql user1
+  end
+
+  it 'should find different model types with same data not equal' do
+    user1 = UserModel.new(first: 'Kartik', last: 'Chandran', email: "Kartik.Chandran@owner.company.com")
+    user2 = OwnerModel.new(first: 'Kartik', last: 'Chandran', email: "Kartik.Chandran@owner.company.com")
+    expect(user1).to_not eql user2
+  end
 end


### PR DESCRIPTION
To address https://github.com/bret/model/issues/2

Equivalency options
1) Ensure all keys that are defined have matching values
2) Ensure the intersection of the keys that are defined have matching values
3) Ensure that all of the keys defined in one object have matching values in the other

My use case is that I am creating an object in my test, using it to populate a form, and then making an API call to verify that the data is properly stored/retrieved. Option 3 allows this use case since I can verify that everything I defined in the object model is represented in the return of the API, without having to strip out id, created_at, etc.

The downside to this approach is that if you have a model where you have set everything (or most things) set to nil, it will return equivalent to any model of the same class. 
