### PR TITLE
allow initialization of model with keys not pre-defined in model

### DIFF
--- a/lib/model.rb
+++ b/lib/model.rb
@@ -28,11 +28,12 @@ class Model
   end
 
   def initialize(hash={})
-    unknown = hash.keys - keys
-    if unknown.count > 0
-      raise ArgumentError, "unknown keyword#{'s' if unknown.count > 1}: #{unknown.join', '}"
+    (hash.keys - keys).each do |k|
+      block = Proc.new {hash[k]}
+      self.class.key(k) {instance_exec(&block)}
     end
-    hash.each_pair {|key, v| instance_variable_set "@#{key}", v}
+
+    hash.each {|key, v| instance_variable_set "@#{key}", v}
     (self.class.defaults.keys - hash.keys).each do |key|
       block = self.class.defaults[key]
       instance_variable_set("@#{key}", instance_exec(&block))

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -49,11 +49,19 @@ describe Model do
     expect(address.keys).to eql [:street1, :street2, :city, :state, :zip]
   end
 
-  it 'should fail if undefined keys are used' do
+  it 'should fail if undefined keys are accessed' do
     address = AddressModel.new
     expect { address.street }.to raise_error(NoMethodError)
-    expect { AddressModel.new(street: '1101 Fifth St') }.to raise_error(ArgumentError, 'unknown keyword: street')
-    expect { AddressModel.new(a: 'hi', b: 'hello') }.to raise_error(ArgumentError, 'unknown keywords: a, b')
+  end
+
+  it 'should add keys that do not have keys already defined in Model' do
+    expect { AddressModel.new(street: '1101 Fifth St') }.to_not raise_error
+    expect { AddressModel.new(a: 'hi', b: 'hello') }.to_not raise_error
+  end
+
+  it 'should allow access to keys that are defined in Model initialization' do
+    address = AddressModel.new(street: '1101 Fifth St')
+    expect(address.street).to be == '1101 Fifth St'
   end
 
   require 'faker'


### PR DESCRIPTION
This is my problem case, and I'm not sure how to solve it otherwise.

Essentially I want to be able to store the results of an API call into a model.
One of the issues we've had is that the developers often continue to add things to the API return that aren't needed for UI work, and can be safely ignored for the purposes of our automation. Our tests fail every time something gets added to the API because the new key has to be explicitly added to our model.

response = RestClient::Request.execute(url: api_endpoint,
                                                                  method: :post,
                                                                  payload: UserModel.new.to_json})

user = UserModel.new(JSON.parse(response))
