### PR TITLE
spec demonstrating problem with asymmetric comparisons

### DIFF
--- a/lib/model.rb
+++ b/lib/model.rb
@@ -25,6 +25,11 @@ class Model
       attr_accessor symbol
       defaults[symbol] = block if block
     end
+
+    def convert(hash)
+      hash.select! { |k| keys.include?(k) }
+      new(hash)
+    end
   end
 
   def initialize(hash={})

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -121,4 +121,28 @@ describe Model do
     expect(user2).to_not eql user1
   end
 
+  class CreditCardModel < Model
+    key(:cc_number) { '4111111111111111' }
+    key(:cc_ccv) { '1234' }
+    key(:exp_month) { 12 }
+    key(:exp_year) { 2017 }
+  end
+
+  it 'should handle asymetric comparisons' do
+    model = CreditCardModel.new(cc_ccv: '4321')
+
+    # Submit Credit Card form with data from Model
+    # Retrieve JSON data from api & convert to hash
+
+    retrieved_from_api = {id: 100,
+                          created_at: 1450902495,
+                          last_digits: '1111',
+                          exp_month: 12,
+                          exp_year: 2017}
+
+    retrieved_model = CreditCardModel.convert(retrieved_from_api)
+
+    expect(model).to be == retrieved_model
+  end
+
 end


### PR DESCRIPTION
This PR is to demonstrate a problem I'm having and is not a request to be merged

I'm using a convert method similar to the one here based on our earlier discussion. The one in my project is a more complicated version that better suits my purposes, though, so I'm not sure if this method belongs in the project.

The real issue I have is that some pieces of sensitive data, are not stored in the database, and I'm not sure the best way to compare two model instances where data is needed to fill a form, but can not be retrieved from the database.

Possible solutions:
1) Use attr_accessor for anything that you don't want to compare (I'm already doing this for storing things from my API calls that I want to hang on to, like id, etc). I don't like this option in this case because I think a fundamental principle of a model should be that anything that is needed to be entered in the UI needs to be represented as a key.

2) Override the == method for this model. Maybe this use case is enough of an edge case that this is the best option.

3) Ensure the missing data is always the default for the class you are using. Since initializing a class without a parameter defined will use the default, then it is like not checking those values. You could make a different model to change defaults if necessary (AmexModel, VisaModel, VisaGoldModel, etc). This seems to rely on knowing/remembering the trick, though and I don't think is intuitive.

4) Create multiple types of keys similar in approach to [how Watirmark does in the views.](https://github.com/convio/watirmark/blob/master/lib/watirmark/page/page_definition.rb#L89) So you'd have options for keys to populate only, verify only, both populate & verify, and neither populate nor verify. If this sounds right (or interesting), I can try to put together some code for it, I'm curious if this is the best path to go down.
