### PR TITLE
implement model subclass whose values can be set and overridden by ENV

### DIFF
--- a/lib/config_model.rb
+++ b/lib/config_model.rb
@@ -1,0 +1,12 @@
+class ConfigModel < Model
+  class << self
+
+    # define a key and an optional block that provides a default value for the key
+    def key(symbol, &block)
+      super
+      env_pattern = symbol.to_s.upcase
+      defaults[symbol] = Proc.new { ENV[env_pattern] } if ENV[env_pattern]
+    end
+  end
+
+end

--- a/spec/config_model_spec.rb
+++ b/spec/config_model_spec.rb
@@ -1,0 +1,41 @@
+lib = File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+ENV['HOST'] = 'http://google.com'
+ENV['BROWSER'] = 'chrome'
+ENV['RESULTS_EMAIL'] = 'foo@example.com'
+
+require 'model'
+require 'config_model'
+
+describe ConfigModel do
+
+  class HostsModel < ConfigModel
+    key(:host)
+    key(:browser)
+    key(:results_email) { 'bar@example.com' }
+    key(:username) { 'jonny5' }
+  end
+
+  it 'should return defined ENV values by default' do
+    hosts = HostsModel.new
+    expect(hosts.host).to eql 'http://google.com'
+    expect(hosts.browser).to eql 'chrome'
+  end
+
+  it 'should return ENV values even if default exists in Model' do
+    hosts = HostsModel.new
+    expect(hosts.results_email).to eql 'foo@example.com'
+  end
+
+  it 'should not return the ENV values if another value is explicitly passed into the model' do
+    hosts = HostsModel.new(browser: 'firefox')
+    expect(hosts.browser).to eql 'firefox'
+  end
+
+  it 'should return default value if no corresponding ENV value is set' do
+    hosts = HostsModel.new
+    expect(hosts.username).to eql 'jonny5'
+  end
+
+end


### PR DESCRIPTION
I'm working to figure out how we are handling our configuration files. We've been using Cheezy's [FigNewton](https://github.com/cheezy/fig_newton) gem, but have been overall dissatisfied. I realized that these configuration objects are not fundamentally different from Model objects. 

We just have several sources for the data: yaml files stored in git (usually for determining which staging environment, etc), yaml files not stored in git (secret passwords, etc), and Environment variables for when running on Jenkins. When setting up my files I found myself doing this all over my config file:

``` Ruby
key(:foo) { ENV['FOO'] }
```

It seemed more appropriate for there to be a subclass of Model that automatically checks for a matching Environment variable for setting the default. 
It isn't necessary, but I thought it might be useful and I'd see what others thought about it.
