### PR TITLE
make namings consistent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in model.gemspec
+# Specify your gem's dependencies in watir_model.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Model
+# WatirModel
 
 This is a simple class for modelling test data. It is based on our experience with [Watirmark::Model::Factory](https://github.com/watirmark/watirmark/blob/master/spec/model_factory_spec.rb).
 
-Please see [spec/model_spec.rb](spec/model_spec.rb) for examples.
+Please see [spec/watir_model_spec.rb](spec/watir_model_spec.rb) for examples.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'test-model'
+gem 'watir_model'
 ```
 
 And then execute:
@@ -23,7 +23,7 @@ Or install it yourself as:
 To use this library:
 
 ```ruby
-require 'model'
+require 'watir_model'
 ```
 
 ## Development
@@ -32,7 +32,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/model/fork )
+1. Fork it ( https://github.com/[my-github-username]/watir_model/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/watir_model.rb
+++ b/lib/watir_model.rb
@@ -1,7 +1,6 @@
-require "model/version"
 require 'pp'
 
-class Model
+class WatirModel
   class << self
 
     attr_writer :keys, :defaults

--- a/lib/watir_model/version.rb
+++ b/lib/watir_model/version.rb
@@ -1,3 +1,3 @@
-class Model
+class WatirModel
   VERSION = "0.2.1"
 end

--- a/spec/watir_model_spec.rb
+++ b/spec/watir_model_spec.rb
@@ -1,10 +1,10 @@
 lib = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'model'
+require 'watir_model'
 
-describe Model do
+describe WatirModel do
 
-  class AddressModel < Model
+  class AddressModel < WatirModel
     key(:street1) { '11800 Domain Blvd' }
     key(:street2)
     key(:city) { 'Austin' }
@@ -61,7 +61,7 @@ describe Model do
   end
 
   require 'faker'
-  class UserModel < Model
+  class UserModel < WatirModel
     key(:first) { Faker::Name.first_name }
     key(:last) { Faker::Name.last_name }
     key(:email) { "#{first}.#{last}@devmail.company.com" }
@@ -78,7 +78,7 @@ describe Model do
   end
 
   it 'should allow a second key definition to replace a previous definition' do
-    class SimpleModel < Model
+    class SimpleModel < WatirModel
       key(:slot) { 'first' }
       key(:slot) { 'second' }
     end
@@ -113,7 +113,7 @@ describe Model do
     expect(user1).to eql user2
   end
 
-  it 'should not find a model equal to its subset' do
+  it 'should not find a watir_model equal to its subset' do
     UserModel.key(:id)
     user1 = UserModel.new(first: 'Kartik', last: 'Chandran')
     user2 = UserModel.new(id: 1, first: 'Kartik', last: 'Chandran')

--- a/watir_model.gemspec
+++ b/watir_model.gemspec
@@ -1,17 +1,17 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'model/version'
+require 'watir_model/version'
 
 Gem::Specification.new do |spec|
-  spec.name = "test-model"
-  spec.version       = Model::VERSION
+  spec.name = "watir_model"
+  spec.version       = WatirModel::VERSION
   spec.authors       = ["Bret Pettichord"]
   spec.email         = ["bret@pettichord.com"]
 
   spec.summary = %q{This is a simple class for modelling test data.}
   spec.description = %q{This is a simple class for modelling test data. It is based on our experience with Watirmark::Model::Factory.}
-  spec.homepage = "https://github.com/bret/model"
+  spec.homepage = "https://github.com/bret/watir_model"
   spec.license = "MIT"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or


### PR DESCRIPTION
If we don't like WatirModel as a name, this PR can at least serve as an example of what all things should get updated in order for the namings to be consistent. It also follows the [underscore convention](http://guides.rubygems.org/name-your-gem/). 
Alternate Preferences?
- TestModel
- DataModel
- TestObjectModel
- DataObjectModel
- TestDataModel
- TestObjectData
